### PR TITLE
Update docker registry

### DIFF
--- a/.openshift-applier/templates/todolist-deploy.yml
+++ b/.openshift-applier/templates/todolist-deploy.yml
@@ -43,7 +43,7 @@ objects:
             name: '${NAME}'
         spec:
           containers:
-            - image: 'docker-registry.default.svc:5000/${NAMESPACE}/${NAME}:${APP_TAG}'
+            - image: '${DOCKER_REGISTRY}/${NAMESPACE}/${NAME}:${APP_TAG}'
               imagePullPolicy: Always
               name: '${NAME}'
               env:
@@ -113,6 +113,11 @@ parameters:
     displayName: Name
     description: The name assigned to all objects and the related imagestream.
     required: true
+  - name: DOCKER_REGISTRY
+    displayName: Docker Registry
+    description: The URL and Port for your internal Docker Registry
+    required: true
+    value: image-registry.openshift-image-registry.svc:5000
   - name: APP_TAG
     displayName: App Tag
     description: The tag of the image to use eg latest.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,8 @@ pipeline {
         PIPELINES_NAMESPACE = "${NAMESPACE_PREFIX}-ci-cd"
         APP_NAME = "todolist"
 
+        DOCKER_REGISTRY = "image-registry.openshift-image-registry.svc:5000"
+
         JENKINS_TAG = "${JOB_NAME}.${BUILD_NUMBER}".replace("/", "-")
         JOB_NAME = "${JOB_NAME}".replace("/", "-")
 
@@ -161,7 +163,7 @@ pipeline {
                 echo '### set env vars and image for deployment ###'
                 sh '''
                     oc set env dc ${APP_NAME} NODE_ENV=${NODE_ENV}
-                    oc set image dc/${APP_NAME} ${APP_NAME}=docker-registry.default.svc:5000/${PROJECT_NAMESPACE}/${APP_NAME}:${JENKINS_TAG}
+                    oc set image dc/${APP_NAME} ${APP_NAME}=${DOCKER_REGISTRY}/${PROJECT_NAMESPACE}/${APP_NAME}:${JENKINS_TAG}
                     oc rollout latest dc/${APP_NAME}
                 '''
                 echo '### Verify OCP Deployment ###'


### PR DESCRIPTION
We have run into a few minor issues with the enablement-docs exercises running on OCP 4.4

This PR will fix the internal docker URL for running on OCP 4.x

It will also make it easier to change with vars/params in the future!